### PR TITLE
Improve nav semantics

### DIFF
--- a/app/dados/page.tsx
+++ b/app/dados/page.tsx
@@ -89,36 +89,38 @@ export default function DadosPage() {
         ))}
       </div>
       {activeCategory && (
-        <div className="space-y-6">
+        <div>
           <h2 className="text-2xl font-semibold mb-4">{activeCategory}</h2>
-          {datasets[activeCategory].map((dataset, index) => (
-            <div key={index} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-              <div className="flex items-center space-x-4">
-                <FileText className="text-blue-900" />
-                <span>{dataset}</span>
-              </div>
-              <div className="flex items-center space-x-2">
-                {/* Visualizar Button */}
-                <button 
-                  onClick={() => {
-                    router.push(`/dados/${encodeURIComponent(dataset)}`)
-                  }}
-                  className="flex items-center space-x-2 px-4 py-2 bg-blue-900 text-white rounded-md hover:bg-blue-800 transition-colors"
-                >
-                  <Eye size={16} />
-                  <span>Visualizar</span>
-                </button>
-                {/* Download Button */}
-                <button
-                  onClick={() => handleDownload(dataset)}
-                  className="flex items-center space-x-2 px-4 py-2 bg-blue-900 text-white rounded-md hover:bg-blue-800 transition-colors"
-                >
-                  <Download size={16} />
-                  <span>Download</span>
-                </button>
-              </div>
-            </div>
-          ))}
+          <ul role="list" className="space-y-6">
+            {datasets[activeCategory].map((dataset, index) => (
+              <li key={index} role="listitem" className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                <div className="flex items-center space-x-4">
+                  <FileText className="text-blue-900" />
+                  <span>{dataset}</span>
+                </div>
+                <div className="flex items-center space-x-2">
+                  {/* Visualizar Button */}
+                  <button
+                    onClick={() => {
+                      router.push(`/dados/${encodeURIComponent(dataset)}`)
+                    }}
+                    className="flex items-center space-x-2 px-4 py-2 bg-blue-900 text-white rounded-md hover:bg-blue-800 transition-colors"
+                  >
+                    <Eye size={16} />
+                    <span>Visualizar</span>
+                  </button>
+                  {/* Download Button */}
+                  <button
+                    onClick={() => handleDownload(dataset)}
+                    className="flex items-center space-x-2 px-4 py-2 bg-blue-900 text-white rounded-md hover:bg-blue-800 transition-colors"
+                  >
+                    <Download size={16} />
+                    <span>Download</span>
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/app/publicacoes/page.tsx
+++ b/app/publicacoes/page.tsx
@@ -212,13 +212,14 @@ function PublicacoesInner() {
             </div>
           </div>
         )}
-        <div className="grid gap-3">
+        <ul role="list" className="grid gap-3">
           {filteredPublications.map(pub => (
-            <div
+            <li
               key={pub.id}
+              role="listitem"
               className="group flex items-center justify-between py-4 border-b border-gray-100 hover:bg-gray-50/50 transition-all duration-200"
             >
-              <div 
+              <div
                 className="flex items-center gap-4 flex-1 cursor-pointer"
                 onClick={() => router.push(`?slug=${encodeURIComponent(pub.slug)}`)}
               >
@@ -255,14 +256,14 @@ function PublicacoesInner() {
                   <span>Download</span>
                 </button>
               )}
-            </div>
+            </li>
           ))}
           {filteredPublications.length === 0 && (
             <div className="text-center py-12 text-gray-500">
               Nenhuma publicação encontrada para os filtros selecionados
             </div>
           )}
-        </div>
+        </ul>
       </div>
     </div>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -36,17 +36,19 @@ export default function Header() {
 
         {/* Centered nav on desktop (absolute positioned) */}
         <div className="hidden md:block absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
-          <nav className="flex items-center justify-center space-x-4">
-            {navItems.map((item) => (
-              <div key={item.name}>
-                <PreloadLink
-                  href={item.href}
-                  className="hover:text-blue-200 transition-colors text-xl font-medium px-1 py-1"
-                >
-                  {item.name}
-                </PreloadLink>
-              </div>
-            ))}
+          <nav>
+            <ul className="flex items-center justify-center space-x-4">
+              {navItems.map((item) => (
+                <li key={item.name}>
+                  <PreloadLink
+                    href={item.href}
+                    className="hover:text-blue-200 transition-colors text-xl font-medium px-1 py-1"
+                  >
+                    {item.name}
+                  </PreloadLink>
+                </li>
+              ))}
+            </ul>
           </nav>
         </div>
 
@@ -76,18 +78,19 @@ export default function Header() {
       {/* Mobile Menu (slides down) */}
       {isOpen && (
         <div className="md:hidden bg-blue-900 border-t border-blue-800">
-          <nav className="px-4 pt-2 pb-4 space-y-2">
-            {navItems.map((item) => (
-              <div key={item.name}>
-                <PreloadLink
-                  href={item.href}
-                  className="block py-2 hover:text-blue-200 transition-colors text-xl"
-                  onClick={() => setIsOpen(false)}
-                >
-                  {item.name}
-                </PreloadLink>
-              </div>
-            ))}
+          <nav className="px-4 pt-2 pb-4">
+            <ul className="space-y-2">
+              {navItems.map((item) => (
+                <li key={item.name}>
+                  <PreloadLink
+                    href={item.href}
+                    className="block py-2 hover:text-blue-200 transition-colors text-xl"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    {item.name}
+                  </PreloadLink>
+                </li>
+              ))}
 
             {/* Right Logo shown at the bottom on mobile (optional) */}
             <div className="pt-4 border-t border-blue-800 flex justify-center">
@@ -100,6 +103,7 @@ export default function Header() {
                 priority
               />
             </div>
+            </ul>
           </nav>
         </div>
       )}


### PR DESCRIPTION
## Summary
- rework Header navigation links as a list
- mark dataset list with `<ul>`/`<li>`
- use list markup for publication listings

## Testing
- `npm run build` *(fails: next not found)*